### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/kabalas1234/0798535a-8cbe-4468-b011-045dc2a0ce8f/7fe50d98-1537-42ff-bf2a-859547ec5f2a/_apis/work/boardbadge/44feb596-eb26-453b-85a7-7efbf8bfb49c)](https://dev.azure.com/kabalas1234/0798535a-8cbe-4468-b011-045dc2a0ce8f/_boards/board/t/7fe50d98-1537-42ff-bf2a-859547ec5f2a/Microsoft.RequirementCategory)
 MP1
 ===


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/kabalas1234/0798535a-8cbe-4468-b011-045dc2a0ce8f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.