### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://codedev.ms/kabalas/c94d4054-4f4c-4655-b9d8-3bcea83657f3/f265a833-cf64-4be9-8c51-6045aa26a742/_apis/work/boardbadge/49a1bf34-b4eb-4bcb-af15-b545797e0a0a)](https://codedev.ms/kabalas/c94d4054-4f4c-4655-b9d8-3bcea83657f3/_boards/board/t/f265a833-cf64-4be9-8c51-6045aa26a742/Microsoft.RequirementCategory)
 MP1
 ===


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://remotelinkingtest1.visualstudio.com/2a3c4959-5a64-4802-a254-1ead1a2578ad/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.